### PR TITLE
Small fixes on mobile

### DIFF
--- a/conjugation/drill.css
+++ b/conjugation/drill.css
@@ -150,6 +150,7 @@ body, input {
 
 #answer:focus {
   outline-width: 0;
+  outline: none;
 }
 
 .correct,

--- a/conjugation/drill.css
+++ b/conjugation/drill.css
@@ -192,7 +192,11 @@ body, input {
 }
 
 input#numQuestions {
-  width: 60px;
+  width: 100%;
+}
+
+select#questionFocus {
+  width: 100%;
 }
 
 div.options ul {

--- a/conjugation/drill.html
+++ b/conjugation/drill.html
@@ -25,19 +25,19 @@
       <dl class="questionOptions mx-auto mb-0">
         <div class="form-group">
           <dt>
-            <label for="numQuestions" class="col-form-label">Number of Questions</label>
+            <label for="numQuestions" class="col-form-label mr-2">Number of Questions</label>
           </dt>
           <dd>
-            <input class="mb-2 ml-2 form-control" style="width: 100%" type="number" placeholder="Questions"
+            <input class="mb-2 form-control" type="number" placeholder="Questions"
               aria-label="Number of Questions" aria-describedby="basic-addon2" id="numQuestions" value="10">
           </dd>
         </div>
         <div class="form-group">
           <dt>
-            <label for="questionFocus" class="col-form-label">Question Focus</label>
+            <label for="questionFocus" class="col-form-label mr-2">Question Focus</label>
           </dt>
           <dd>
-            <select id="questionFocus" class="form-control ml-2" aria-label="Question Focus">
+            <select id="questionFocus" class="form-control" aria-label="Question Focus">
               <option value="none">None</option>
               <option value="politeness">Politeness</option>
               <option value="negative">Negative</option>

--- a/conjugation/drill.html
+++ b/conjugation/drill.html
@@ -233,7 +233,7 @@
     <div id="inputArea" class="row">
       <div class="col-12">
         <form action="javascript:processAnswer()">
-          <input placeholder="答え" autocomplete="off" id="answer" aria-label="答え">
+          <input placeholder="答え" autocomplete="off" autocapitalize="off" id="answer" aria-label="答え">
         </form>
       </div>
     </div>


### PR DESCRIPTION
This pull request is about fixing three things mostly related to handled devices (at least iOS Safari).

**Larger right margin on the settings page**

<img src="https://user-images.githubusercontent.com/293337/136604593-5a40d8ec-f429-49b3-a376-d6616a3f56dc.jpg" width="50%" />

---

**Disable the outline on the answer input**

<img src="https://user-images.githubusercontent.com/293337/136604840-ed390f53-bb53-4578-a66c-a86df2c386c4.png" width="50%" />

---

**Disable the capitalized first letter on the answer input**

<img src="https://user-images.githubusercontent.com/293337/136605009-ddb3ec3f-7fd0-4fc3-86d9-05c5473f31f9.png" width="50%" />


